### PR TITLE
input/keyboard: send released only if pressed sent

### DIFF
--- a/include/sway/input/keyboard.h
+++ b/include/sway/input/keyboard.h
@@ -60,6 +60,7 @@ struct sway_keyboard {
 	struct sway_shortcut_state state_keysyms_translated;
 	struct sway_shortcut_state state_keysyms_raw;
 	struct sway_shortcut_state state_keycodes;
+	struct sway_shortcut_state state_pressed_sent;
 	struct sway_binding *held_binding;
 
 	struct wl_event_source *key_repeat_source;


### PR DESCRIPTION
This keeps track of whether surfaces received a key press event and
will only send a key release event if the pressed event was sent. This
also requires changing the keycodes that are sent via wl_keyboard_enter
to only include those that were previously sent. This makes it so
surfaces do not receive key release events for keys that they never
received a key press for and makes it so switching focus doesn't leak
keycodes that were consumed by bindings.