### PR TITLE
sway.5: remove mention of floating_scroll

### DIFF
--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -536,11 +536,6 @@ The default colors are:
 	windows, and right click to resize them. If _inverse_ is specified, left
 	click is used for resizing and right click for moving.
 
-*floating_scroll* up|right|down|left [command]
-	Sets a command to be executed when the mouse wheel is scrolled in the
-	specified direction while holding the floating modifier. Resets the
-	command, when given no arguments.
-
 *focus_follows_mouse* yes|no|always
 	If set to _yes_, moving your mouse over a window will focus that window. If
 	set to _always_, the window under the cursor will always be focused, even


### PR DESCRIPTION
It looks like floating_scroll was still in the sway(5) man page as a
remnant of the 0.x era. This just removes it from the man page since it
is no longer a valid command. Mouse bindings with Button4-7 can be used
instead